### PR TITLE
Enable use of multiple vCPUs in the VM image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,8 @@ fi
 
 $vmsh createVM  $VM_ISO_LINK $osname $ostype $sshport
 
+# Enable multi-processor so that the MP kernel gets installed.
+$vmsh setCPU $osname 2
 
 
 $vmsh startWeb $osname


### PR DESCRIPTION
If the VM only has a single vCPU during the build, the OpenBSD installer will install the 'single processor' kernel. The vmactions/openbsd-vm action [sets the number of vCPUs](https://github.com/vmactions/openbsd-vm/blob/main/index.js#L66) to `3` which ends up having no effect because the SP kernel doesn't probe the addition vCPUs. With this PR, the VM will be able to use all 3 cores.