### PR TITLE
Only start web and CF tunnel if $DEBUG is set

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,17 +75,13 @@ $vmsh createVM  $VM_ISO_LINK $osname $ostype $sshport
 # Enable multi-processor so that the MP kernel gets installed.
 $vmsh setCPU $osname 2
 
-
-$vmsh startWeb $osname
-
-
-
-$vmsh startCF
-
-
-_sleep=20
-echo "Sleep $_sleep seconds, please open the link in your browser."
-sleep $_sleep
+if [ -n "$DEBUG" ]; then
+    $vmsh startWeb $osname
+    $vmsh startCF
+    _sleep=20
+    echo "Sleep $_sleep seconds, please open the link in your browser."
+    sleep $_sleep
+fi
 
 $vmsh startVM $osname
 


### PR DESCRIPTION
This brings the builder action in line with the vm action (which also conditionally enables the CF tunnel).

NOTE: I'm only submitting a PR for the openbsd-builder action as that's the one I'm working with, but the rest of the builder actions could use the same treatment.