### PR TITLE
Finish vio0 changes, use latest vbox.sh and fix rsync package name.

### DIFF
--- a/conf/openbsd-7.7-aarch64.conf
+++ b/conf/openbsd-7.7-aarch64.conf
@@ -15,7 +15,7 @@ VM_INSTALL_CMD="pkg_add"
 
 #search for the latest rsync version here
 #https://cdn.openbsd.org/pub/OpenBSD/7.7/packages/aarch64/
-VM_RSYNC_PKG="rsync-3.4.1"
+VM_RSYNC_PKG="rsync--"
 VM_SSHFS_PKG="sshfs-fuse"
 
 VM_PRE_INSTALL_PKGS="tree $VM_RSYNC_PKG $VM_SSHFS_PKG"
@@ -31,7 +31,7 @@ VM_OPTS="conf/openbsd-7.7-aarch64.resp"
 
 VM_VBOX="./vbox.sh"
 
-VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.3/vbox.sh"
+VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.4/vbox.sh"
 
 
 

--- a/conf/openbsd-7.7-aarch64.resp
+++ b/conf/openbsd-7.7-aarch64.resp
@@ -1,7 +1,7 @@
 System hostname = openbsd
 Network interface to configure = vio0
-IPv4 address for em0 = autoconf
-IPv6 address for em0 = none
+IPv4 address for vio0 = autoconf
+IPv6 address for vio0 = none
 Network interface to configure = done
 Password for root account = $2b$10$qS3/zFLn/6wTQrjNhAddEepvKw.XculyRsXH60FLXjcj5fQeZzIQu
 Start sshd(8) by default = yes

--- a/conf/openbsd-7.7.conf
+++ b/conf/openbsd-7.7.conf
@@ -15,7 +15,7 @@ VM_INSTALL_CMD="pkg_add"
 
 #search for the latest rsync version here
 #https://cdn.openbsd.org/pub/OpenBSD/7.7/packages/amd64/
-VM_RSYNC_PKG="rsync-3.4.1"
+VM_RSYNC_PKG="rsync--"
 VM_SSHFS_PKG="sshfs-fuse"
 
 VM_PRE_INSTALL_PKGS="tree $VM_RSYNC_PKG $VM_SSHFS_PKG"
@@ -29,7 +29,7 @@ VM_OPTS="conf/openbsd-7.7.resp"
 
 VM_VBOX="./vbox.sh"
 
-VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.3/vbox.sh"
+VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.4/vbox.sh"
 
 
 

--- a/conf/openbsd-7.7.resp
+++ b/conf/openbsd-7.7.resp
@@ -1,7 +1,7 @@
 System hostname = openbsd
 Network interface to configure = vio0
-IPv4 address for em0 = autoconf
-IPv6 address for em0 = none
+IPv4 address for vio0 = autoconf
+IPv6 address for vio0 = none
 Network interface to configure = done
 Password for root account = $2b$10$qS3/zFLn/6wTQrjNhAddEepvKw.XculyRsXH60FLXjcj5fQeZzIQu
 Start sshd(8) by default = yes

--- a/conf/openbsd-7.8-aarch64.conf
+++ b/conf/openbsd-7.8-aarch64.conf
@@ -15,7 +15,7 @@ VM_INSTALL_CMD="pkg_add"
 
 #search for the latest rsync version here
 #https://cdn.openbsd.org/pub/OpenBSD/7.8/packages/aarch64/
-VM_RSYNC_PKG="rsync-3.4.1"
+VM_RSYNC_PKG="rsync--"
 VM_SSHFS_PKG="sshfs-fuse"
 
 VM_PRE_INSTALL_PKGS="tree $VM_RSYNC_PKG $VM_SSHFS_PKG"
@@ -31,7 +31,7 @@ VM_OPTS="conf/openbsd-7.8-aarch64.resp"
 
 VM_VBOX="./vbox.sh"
 
-VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.3/vbox.sh"
+VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.4/vbox.sh"
 
 
 

--- a/conf/openbsd-7.8-aarch64.resp
+++ b/conf/openbsd-7.8-aarch64.resp
@@ -1,7 +1,7 @@
 System hostname = openbsd
 Network interface to configure = vio0
-IPv4 address for em0 = autoconf
-IPv6 address for em0 = none
+IPv4 address for vio0 = autoconf
+IPv6 address for vio0 = none
 Network interface to configure = done
 Password for root account = $2b$10$qS3/zFLn/6wTQrjNhAddEepvKw.XculyRsXH60FLXjcj5fQeZzIQu
 Start sshd(8) by default = yes

--- a/conf/openbsd-7.8.conf
+++ b/conf/openbsd-7.8.conf
@@ -15,7 +15,7 @@ VM_INSTALL_CMD="pkg_add"
 
 #search for the latest rsync version here
 #https://cdn.openbsd.org/pub/OpenBSD/7.8/packages/amd64/
-VM_RSYNC_PKG="rsync-3.4.1"
+VM_RSYNC_PKG="rsync--"
 VM_SSHFS_PKG="sshfs-fuse"
 
 VM_PRE_INSTALL_PKGS="tree $VM_RSYNC_PKG $VM_SSHFS_PKG"
@@ -29,7 +29,7 @@ VM_OPTS="conf/openbsd-7.8.resp"
 
 VM_VBOX="./vbox.sh"
 
-VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.3/vbox.sh"
+VM_VBOX_LINK="https://raw.githubusercontent.com/vmactions/vbox/v1.1.4/vbox.sh"
 
 
 

--- a/conf/openbsd-7.8.resp
+++ b/conf/openbsd-7.8.resp
@@ -1,7 +1,7 @@
 System hostname = openbsd
 Network interface to configure = vio0
-IPv4 address for em0 = autoconf
-IPv6 address for em0 = none
+IPv4 address for vio0 = autoconf
+IPv6 address for vio0 = none
 Network interface to configure = done
 Password for root account = $2b$10$qS3/zFLn/6wTQrjNhAddEepvKw.XculyRsXH60FLXjcj5fQeZzIQu
 Start sshd(8) by default = yes


### PR DESCRIPTION
Thank you for accepting the vbox.sh changes. This finishes the change you started to use virtio. Updates to use the latest vbox.sh and removes the version number from rsync.

I noticed you were including the full version number of the rsync package. This is not great because you have to look it up each release and keep it in sync with what was released. I presume you did this because there are two rsync packages, the full one and -minimal. The way to select the main package without a version number is to use the package name with two dashes after it. See [pkg_add(1)](https://man.openbsd.org/pkg_add.1)

Prior to the virtio changes, the openbsd-builder occasionally fails one of the 4 builds. This is still happening. It seems related to enablessh.txt not working on the guest correctly. I've seen it not create ~/.ssh/id_rsa and also fail to put AcceptEnv * in to sshd_config so the last step of the build process fails when it checks that its the env is working. Not sure what is causing it to fail intermittently. 