### PR TITLE
Run syspatch twice

### DIFF
--- a/hooks/postBuild.sh
+++ b/hooks/postBuild.sh
@@ -12,7 +12,7 @@ done
 echo "OK, start syspatch"
 
 syspatch
-
+syspatch
 
 ret="$?"
 #0 means ok


### PR DESCRIPTION
In 7.8 the first syspatch is to the syspatch program itself. The first run of syspatch fixes syspatch and stops with:

syspatch: updated itself, run it again to install missing patches

so it needs to be run a second time to get the remaining syspatches. Running it twice on 7.7 wont hurt.